### PR TITLE
add DM shared key vector + clarify spec

### DIFF
--- a/direct-messages/README.md
+++ b/direct-messages/README.md
@@ -15,18 +15,21 @@ because the same message can simultaneously:
 We define a shared key that the sender + recipient can both derive:
 
 ```js
+
 function computeDirectMessageKey (my_secret, your_public) {
   var hash = 'SHA256'
-  var salt = SHA256("envelope-direct-messsage-shared-key-extract-salt")
   var input_keying_material = scalarmult(my_secret, your_public)
+  var salt = "envelope-id-based-dm-converted-ed25519"
+  // see 'private-group-spec/direct-messages/constants.json'
 
-  return hkdf.Extract(hash, salt, input_keying_material)
+  return hkdf.Extract(hash, input_keying_material, salt)
 }
 ```
 
 Notes:
 - we (curently) use the primary feed keys for this derivation
 - for feeds based on `ed25519` keypairs, we convert these to `curve25519` keypairs before doing scalarmult
+- note this uses `hkdf.Extract` (while other parts of this stack use `hkdf.Expand`)
 
 
 ## Using `feed_id`

--- a/direct-messages/constants.json
+++ b/direct-messages/constants.json
@@ -1,0 +1,3 @@
+{
+  "SALT": "envelope-id-based-dm-converted-ed25519"
+}

--- a/vectors/direct-message-key1.json
+++ b/vectors/direct-message-key1.json
@@ -1,0 +1,16 @@
+{
+  "type": "direct_message_shared_key",
+  "description": "calculate a shared DM key for another feedID",
+  "input": {
+    "my_keys": {
+      "curve": "ed25519",
+      "public": "PgtHJT1L29Gh6wmS4Q9UDeUJZ6ZSkTFgryoHy02gKpc=.ed25519",
+      "private": "GSxyffiCY9IIgPNr+zA5ce5Se8x47Rc5jLZEAnJFhOA+C0clPUvb0aHrCZLhD1QN5QlnplKRMWCvKgfLTaAqlw==.ed25519",
+      "id": "@PgtHJT1L29Gh6wmS4Q9UDeUJZ6ZSkTFgryoHy02gKpc=.ed25519"
+    },
+    "feed_id": "@JnyVm12Cj247NCvFZgGy1v2HfISN3UvA5mJ2mXFzVwg=.ed25519"
+  },
+  "output": {
+    "shared_key": "xjsK+Lbt8WhB3aDre42Sb/fGwylHyTL5rBFP6qCKMtk="
+  }
+}


### PR DESCRIPTION
Finally!
A test vector deriving a simple shared symmetric key for two feeds.

This is needed for doing direct messages using envelope encryption, particularly in the case of `group/add-member` messages.

@keks I'd be interested to know if you think the README is clear, and what I've coded is right.

Here's [the JS implementation](https://github.com/ssbc/ssb-private2/blob/invite/lib/direct-message-key.js) in case that's useful